### PR TITLE
插件市场页面优化

### DIFF
--- a/docs/.vitepress/theme/PluginMarket.vue
+++ b/docs/.vitepress/theme/PluginMarket.vue
@@ -26,15 +26,6 @@ onMounted(async () => {
         const response = await fetch('https://pm.tooldelta.top/market_tree.json')
         const data = await response.json()
 
-        // 将插件转换为数组
-        const plugins = []
-        for (const key in data.MarketPlugins) {
-            plugins.push({
-                ...data.MarketPlugins[key],
-                isPackage: false
-            })
-        }
-
         // 将整合包转换为数组
         const packages = []
         for (const key in data.Packages) {
@@ -45,6 +36,34 @@ onMounted(async () => {
                 description: data.Packages[key].description,
                 isPackage: true
             })
+        }
+
+        // 将插件转换为数组并获取描述
+        const plugins = []
+        const pluginIdsMap = await fetch('https://pm.tooldelta.top/plugin_ids_map.json').then(r => r.json())
+
+        for (const pluginId in data.MarketPlugins) {
+            const pluginInfo = data.MarketPlugins[pluginId]
+            const pluginName = pluginIdsMap[pluginId]
+
+            if (pluginName) {
+                try {
+                    const datasResponse = await fetch(`https://pm.tooldelta.top/${pluginName}/datas.json`)
+                    const datasJson = await datasResponse.json()
+
+                    plugins.push({
+                        ...pluginInfo,
+                        description: datasJson.description || '暂无描述',
+                        isPackage: false
+                    })
+                } catch (e) {
+                    plugins.push({
+                        ...pluginInfo,
+                        description: '暂无描述',
+                        isPackage: false
+                    })
+                }
+            }
         }
 
         // 合并整合包和插件，整合包放在前面

--- a/docs/.vitepress/theme/PluginMarket.vue
+++ b/docs/.vitepress/theme/PluginMarket.vue
@@ -1,8 +1,8 @@
 <template>
-    <h2>插件</h2>
+    <h2>插件与整合包</h2>
     <div v-if="loading">加载中...</div>
     <div v-else>
-        <div class="plugin-card" v-for="item in pluginList" :key="item.name">
+        <div class="plugin-card" v-for="item in itemList" :key="item.name" :class="{ 'package-card': item.isPackage }">
             <div class="plugin-header">
                 <div class="plugin-name">{{ item.name }}</div>
             </div>
@@ -18,21 +18,37 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
-const pluginList = ref([])
+const itemList = ref([])
 const loading = ref(true)
 
 onMounted(async () => {
     try {
         const response = await fetch('https://pm.tooldelta.top/market_tree.json')
         const data = await response.json()
-        
-        // 将对象转换为数组
+
+        // 将插件转换为数组
         const plugins = []
         for (const key in data.MarketPlugins) {
-            plugins.push(data.MarketPlugins[key])
+            plugins.push({
+                ...data.MarketPlugins[key],
+                isPackage: false
+            })
         }
-        
-        pluginList.value = plugins
+
+        // 将整合包转换为数组
+        const packages = []
+        for (const key in data.Packages) {
+            packages.push({
+                name: `[整合包] ${key}`,
+                author: data.Packages[key].author,
+                version: data.Packages[key].version,
+                description: data.Packages[key].description,
+                isPackage: true
+            })
+        }
+
+        // 合并整合包和插件，整合包放在前面
+        itemList.value = [...packages, ...plugins]
     } catch (error) {
         console.error('加载插件数据失败:', error)
     } finally {
@@ -63,6 +79,10 @@ onMounted(async () => {
     background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
     color: white;
     position: relative;
+}
+
+.package-card .plugin-header {
+    background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
 }
 
 .plugin-name {


### PR DESCRIPTION
- 支持整合包显示，整合包在列表前端并使用独特样式区分
- 从插件 datas.json 获取完整描述信息
- 响应式网格布局：桌面两列，移动端单列
- 适配深浅主题，颜色和阴影随主题自动切换
- 点击插件名可跳转到 GitHub 对应文件夹
- 修正 GitHub 仓库地址和整合包路径编码